### PR TITLE
New DB Schema for Tagging Transactions

### DIFF
--- a/godbledger/db/mysql/mysqldb.go
+++ b/godbledger/db/mysql/mysqldb.go
@@ -103,6 +103,21 @@ func (db *Database) InitDB() error {
 		log.Fatal(err)
 	}
 
+	//TAGS FOR Transactions
+	createDB = `
+	CREATE TABLE IF NOT EXISTS transaction_tag (
+    transaction_id VARCHAR(255) NOT NULL,
+    tag_id INTEGER NOT NULL,
+    FOREIGN KEY (transaction_id) REFERENCES transactions (transaction_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    FOREIGN KEY (tag_id) REFERENCES tags (tag_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    PRIMARY KEY (transaction_id, tag_id)
+	);`
+	log.Debug("Query: " + createDB)
+	_, err = db.DB.Exec(createDB)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	//CURRENCIES
 	createDB = `
 	CREATE TABLE IF NOT EXISTS currencies (

--- a/godbledger/db/sqlite3/sqlite3db.go
+++ b/godbledger/db/sqlite3/sqlite3db.go
@@ -96,6 +96,21 @@ func (db *Database) InitDB() error {
 		log.Fatal(err)
 	}
 
+	//TAGS FOR Transactions
+	createDB = `
+	CREATE TABLE IF NOT EXISTS transaction_tag (
+    transaction_id VARCHAR(255) NOT NULL,
+    tag_id INTEGER NOT NULL,
+    FOREIGN KEY (transaction_id) REFERENCES transactions (transaction_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    FOREIGN KEY (tag_id) REFERENCES tags (tag_id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    PRIMARY KEY (transaction_id, tag_id)
+	);`
+	log.Debug("Query: " + createDB)
+	_, err = db.DB.Exec(createDB)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	//CURRENCIES
 	createDB = `
 	CREATE TABLE IF NOT EXISTS currencies (


### PR DESCRIPTION
addresses #25 

Creates a new table for the MySQL and SQLite Tables for linking tags to transactions. 

Current intent is to be able to tag transactions as void so the system can ignore them, however I can imagine they will be useful for other things down the track (Tracking transactions relating to projects, salespersons transactions etc)