### PR TITLE
Creating -clear-db flag to wipe mysql database

### DIFF
--- a/godbledger/db/mysqldb/mysqldb.go
+++ b/godbledger/db/mysqldb/mysqldb.go
@@ -219,19 +219,34 @@ func (db *Database) ClearDB() error {
 
 	//DROP TABLES
 	dropDB := `
-				SET foreign_key_checks = 0;
-				SELECT
-					 'DROP TABLE IF EXISTS ' + table_name + ';'
-				FROM
-						information_schema.tables
-				WHERE
-						table_schema = "ledger";
-				SET foreign_key_checks = 0;
+				DROP DATABASE ledger;
 			`
 	log.Debug("Query: " + dropDB)
 	_, err := db.DB.Exec(dropDB)
 	if err != nil {
 		log.Fatalf("Dropping table failed with: %s", err)
+		return err
+	}
+
+	//CREATE NEW DATABASE
+	newDB := `
+				CREATE DATABASE ledger;
+			`
+	log.Debug("Query: " + newDB)
+	_, err = db.DB.Exec(newDB)
+	if err != nil {
+		log.Fatalf("Creating table failed with: %s", err)
+		return err
+	}
+
+	//USE NEW DATABASE
+	newDB = `
+				USE ledger;
+			`
+	log.Debug("Query: " + newDB)
+	_, err = db.DB.Exec(newDB)
+	if err != nil {
+		log.Fatalf("Creating table failed with: %s", err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Primarily want this for testing so that the command line can run many
tests and be able to start with a clear database. Didn't particularly
want to drop the whole database and recreate but attempts at dropping
all tables previously had failed.

addresses #27 