### PR TITLE
Validating Connection Strings to MySQL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.6.0
+	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	google.golang.org/grpc v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,7 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -132,6 +133,7 @@ github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222/go.mod h1:VyrYX9gd7ir
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -158,6 +160,7 @@ github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3/go.mod h1:hpGUW
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
@@ -240,6 +243,7 @@ gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200603215123-a4a8cb9d2cbc/go.mod h1:uAJ
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/godbledger/db/mysqldb/mysql_test.go
+++ b/godbledger/db/mysqldb/mysql_test.go
@@ -1,0 +1,41 @@
+//
+//  go-unit-test-sql
+//
+//  Copyright © 2020. All rights reserved.
+//  https://medium.com/@bismobaruno/unit-test-sql-in-golang-5af19075e68e
+//
+
+package mysqldb
+
+import (
+	//"database/sql"
+	//"log"
+	"testing"
+
+	//"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateConnectionString(t *testing.T) {
+
+	//Test Regular string with no params
+	validatedString, err := ValidateConnectionString("godbledger:password@tcp(192.168.1.98:3306)/ledger")
+	assert.Nil(t, err)
+	if assert.NotNil(t, validatedString, "Connection String with no params") {
+		assert.Equal(t, "godbledger:password@tcp(192.168.1.98:3306)/ledger?parseTime=true&charset=utf8", validatedString)
+	}
+
+	//Test Same String with a param to ensure no duplication
+	validatedString, err = ValidateConnectionString("godbledger:password@tcp(192.168.1.98:3306)/ledger?parseTime=true")
+	assert.Nil(t, err)
+	if assert.NotNil(t, validatedString, "Connection String with param") {
+		assert.Equal(t, "godbledger:password@tcp(192.168.1.98:3306)/ledger?parseTime=true&charset=utf8", validatedString)
+	}
+
+	//Test empty string to ensure error
+	nilString, err := ValidateConnectionString("")
+	if assert.NotNil(t, err, "Nil connection string") {
+		assert.Equal(t, "Connection string not provided", err.Error())
+	}
+	assert.Equal(t, "", nilString)
+}

--- a/godbledger/db/mysqldb/mysqldb.go
+++ b/godbledger/db/mysqldb/mysqldb.go
@@ -2,10 +2,11 @@ package mysqldb
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/sirupsen/logrus"
 
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql"
 )
 
 var log = logrus.WithField("prefix", "MySQL")
@@ -20,26 +21,51 @@ func (db *Database) Close() error {
 	return db.DB.Close()
 }
 
-func DSN(DB_USER, DB_PASS, DB_HOST, DB_NAME string) string {
-	return DB_USER + ":" + DB_PASS + "@" + DB_HOST + "/" + DB_NAME + "?charset=utf8&parseTime=true"
-	//return DB_USER + ":" + DB_PASS + "@" + DB_HOST + "/"
-}
+func ValidateConnectionString(dsn string) (string, error) {
 
-func ValidateConnectionString(connection_string string) string {
-	//if connection_string == "" {
-	//DB_HOST := "tcp(127.0.0.1:3306)"
-	//DB_NAME := "ledger"
-	//DB_USER := "godbledger"
-	//DB_PASS := "password"
-	//connection_string = DSN(DB_USER, DB_PASS, DB_HOST, DB_NAME)
-	//}
-	return connection_string + "?charset=utf8&parseTime=true"
+	if dsn == "" {
+		return "", errors.New("Connection string not provided")
+	}
+
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		log.Warnf("Connection string could not be parsed: %s", err.Error())
+		return "", err
+	}
+	log.Debugf("DB_ADDR := %s", cfg.Addr)
+	log.Debugf("DB_NET := %s", cfg.Net)
+	log.Debugf("DB_DBNAME := %s", cfg.DBName)
+	log.Debugf("DB_USER := %s", cfg.User)
+	log.Debugf("DB_PASSWORD := %s", cfg.Passwd)
+	log.Debugf("PARAMS := %v", cfg.Params)
+	if !cfg.ParseTime {
+		cfg.ParseTime = true
+	}
+	charset, ok := cfg.Params["charset"]
+	if !(ok && charset == "utf8") {
+		if cfg.Params == nil {
+			cfg.Params = make(map[string]string)
+		}
+		cfg.Params["charset"] = "utf8"
+	}
+
+	log.Debugf("ParseTime := %v", cfg.ParseTime)
+	log.Debugf("Charset := %s", cfg.Params["charset"])
+
+	dsnstring := cfg.FormatDSN()
+	log.Debugf("DSN := %s", dsnstring)
+
+	return dsnstring, nil
 }
 
 // NewDB initializes a new DB.
 func NewDB(connection_string string) (*Database, error) {
-	log.Debug(connection_string)
-	MySQLDB, err := sql.Open("mysql", ValidateConnectionString(connection_string))
+	validatedString, err := ValidateConnectionString(connection_string)
+	if err != nil {
+		log.Fatal(err.Error())
+		return nil, err
+	}
+	MySQLDB, err := sql.Open("mysql", validatedString)
 	if err != nil {
 		log.Fatal(err.Error())
 		return nil, err


### PR DESCRIPTION
As the system adds params to the connection string we want to ensure
that if the user adds their own params that it won't cause errors. These
params are now added programmatically using the mysql drivers config
rather than appending the query string to the connection string.

Addresses #31 