### PR TITLE
Makefile update to include CGO in arm builds, start implementing xgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ VERSION ?= latest
 PLATFORMS := linux
 os = $(word 1, $@)
 
+GOBIN = ./build/bin
+GO ?= latest
+GORUN = env GO111MODULE=on go run
+
 .PHONY: $(PLATFORMS)
 $(PLATFORMS):
 		mkdir -p release/$(BINARY)-$(os)-x64-v$(VERSION)/
@@ -21,5 +25,28 @@ travis:
 
 arm:
 		mkdir -p release/$(BINARY)-arm-x64-v$(VERSION)/
-		GOOS=linux GOARCH=arm GOARM=5 GO111MODULE=on go build -o release/$(BINARY)-$(os)-x64-v$(VERSION)/ ./...
+		env CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7 GO111MODULE=on go build -o release/$(BINARY)-$(os)-x64-v$(VERSION)/ ./...
 
+godbledger-linux-arm: godbledger-linux-arm-5 godbledger-linux-arm-6 godbledger-linux-arm-7 godbledger-linux-arm64
+	@echo "Linux ARM cross compilation done:"
+	@ls -ld $(GOBIN)/godbledger-linux-* | grep arm
+
+godbledger-linux-arm-5:
+	$(GORUN) utils/ci.go xgo -- --go=$(GO) --targets=linux/arm-5 -v ./..
+	@echo "Linux ARMv5 cross compilation done:"
+	@ls -ld $(GOBIN)/godbledger-linux-* | grep arm-5
+
+godbledger-linux-arm-6:
+	$(GORUN) utils/ci.go xgo -- --go=$(GO) --targets=linux/arm-6 -v ./godbledger
+	@echo "Linux ARMv6 cross compilation done:"
+	@ls -ld $(GOBIN)/godbledger-linux-* | grep arm-6
+
+godbledger-linux-arm-7:
+	$(GORUN) utils/ci.go xgo -- --go=$(GO) --targets=linux/arm-7 -v ./godbledger
+	@echo "Linux ARMv7 cross compilation done:"
+	@ls -ld $(GOBIN)/godbledger-linux-* | grep arm-7
+
+godbledger-linux-arm64:
+	$(GORUN) utils/ci.go xgo -- --go=$(GO) --targets=linux/arm64 -v ./godbledger
+	@echo "Linux ARM64 cross compilation done:"
+	@ls -ld $(GOBIN)/godbledger-linux-* | grep arm64

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/ethereum/go-ethereum v1.9.15
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang/protobuf v1.4.2
+	github.com/gophers/xgo v0.0.0-20200104073656-1317f74b9001 // indirect
 	github.com/joyt/godate v0.0.0-20150226210126-7151572574a7
+	github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7 // indirect
 	github.com/marcmak/calc v0.0.0-20150509200512-5bbbfc3b3149
 	github.com/mattn/go-colorable v0.1.7
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
@@ -20,4 +22,5 @@ require (
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	google.golang.org/grpc v1.30.0
+	src.techknowlogick.com/xgo v1.0.1-0.20200717030703-5c3bb7fc435e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gophers/xgo v0.0.0-20200104073656-1317f74b9001 h1:5UcJnp2/fZ9MGc8O9Tb3mBXr+WMd2hUpdlfFWv90MaU=
+github.com/gophers/xgo v0.0.0-20200104073656-1317f74b9001/go.mod h1:HENK69XtUT+Fbtp4t7ijgCw8c5khHVOuzzzZcKGC57A=
 github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
@@ -93,6 +95,8 @@ github.com/joyt/godate v0.0.0-20150226210126-7151572574a7 h1:2wH5antjhmU3EuWyidm
 github.com/joyt/godate v0.0.0-20150226210126-7151572574a7/go.mod h1:R+UgFL3iylLhx9N4w35zZ2HdhDlgorRDx4SxbchWuN0=
 github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
+github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7 h1:AYzjK/SHz6m6mg5iuFwkrAhCc14jvCpW9d6frC9iDPE=
+github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7/go.mod h1:iYGcTYIPUvEWhFo6aKUuLchs+AV4ssYdyuBbQJZGcBk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -248,3 +252,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+src.techknowlogick.com/xgo v1.0.1-0.20200717030703-5c3bb7fc435e h1:cNlfcCyMwIq/KyKPgpuPohdDr9EjtxX0b44sGYSV2Ic=
+src.techknowlogick.com/xgo v1.0.1-0.20200717030703-5c3bb7fc435e/go.mod h1:31CE1YKtDOrKTk9PSnjTpe6YbO6W/0LTYZ1VskL09oU=

--- a/utils/make-release.sh
+++ b/utils/make-release.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 version=$1
-build=linux
+#build=linux
+build=arm
 
 if [ -z "$version" ]
 then


### PR DESCRIPTION
using `make arm` the binaries for arm can be compiled. Attempted to
implement a more comprehensive build using Geths xgo from the ci.go
script however having issues as it appears to not be maintained. Will
need further investigation into making the arm build work using that
method.

Attempts to address #63 