### PR TITLE
Implement Host option in config file

### DIFF
--- a/godbledger/cmd/config.go
+++ b/godbledger/cmd/config.go
@@ -16,6 +16,7 @@ import (
 var log = logrus.WithField("prefix", "Config")
 
 type LedgerConfig struct {
+	Host             string // Host defines the address that the RPC will be opened on. Combined with RPC Port
 	RPCPort          string // RPCPort defines the port that the server will listen for transactions on
 	DataDirectory    string // DataDirectory defines the host systems folder directory holding the database and config files
 	LogVerbosity     string // LogVerbosity defines the logging level {debug, info, warn, error, fatal, panic}
@@ -50,6 +51,7 @@ var (
 	}
 
 	defaultLedgerConfig = &LedgerConfig{
+		Host:             "127.0.0.1",
 		RPCPort:          "50051",
 		DataDirectory:    DefaultDataDir(),
 		LogVerbosity:     "debug",

--- a/godbledger/main.go
+++ b/godbledger/main.go
@@ -30,7 +30,7 @@ func startNode(ctx *cli.Context) error {
 		return err
 	}
 	fullnode.Register(ledger)
-	rpc := rpc.NewRPCService(context.Background(), &rpc.Config{Port: cfg.RPCPort}, ledger)
+	rpc := rpc.NewRPCService(context.Background(), &rpc.Config{Port: cfg.RPCPort, Host: cfg.Host}, ledger)
 	fullnode.Register(rpc)
 	fullnode.Start()
 

--- a/godbledger/rpc/service.go
+++ b/godbledger/rpc/service.go
@@ -25,10 +25,12 @@ type Service struct {
 	grpcServer *grpc.Server
 	listener   net.Listener
 	port       string
+	host       string
 }
 
 type Config struct {
 	Port string
+	Host string
 }
 
 func NewRPCService(ctx context.Context, cfg *Config, l *ledger.Ledger) *Service {
@@ -38,15 +40,17 @@ func NewRPCService(ctx context.Context, cfg *Config, l *ledger.Ledger) *Service 
 		ctx:    ctx,
 		cancel: cancel,
 		port:   cfg.Port,
+		host:   cfg.Host,
 	}
 }
 
 // Start the gRPC server.
 func (s *Service) Start() {
 	log.Info("Starting service")
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", s.port))
+	address := fmt.Sprintf("%s:%s", s.host, s.port)
+	lis, err := net.Listen("tcp", address)
 	if err != nil {
-		log.Errorf("Could not listen to port in Start() :%s: %v", s.port, err)
+		log.Errorf("Could not listen to port in Start() %s: %v", address, err)
 	}
 	s.listener = lis
 	log.WithField("port", s.port).Info("Listening on port")


### PR DESCRIPTION
New config string for host which defaults to 127.0.0.1 this is
passed into the GRPC service startup rather than using its defaults.

addresses #60 