### PR TITLE
Added GRPC security to endpoints

### DIFF
--- a/godbledger/cmd/config.go
+++ b/godbledger/cmd/config.go
@@ -18,6 +18,8 @@ var log = logrus.WithField("prefix", "Config")
 type LedgerConfig struct {
 	Host             string // Host defines the address that the RPC will be opened on. Combined with RPC Port
 	RPCPort          string // RPCPort defines the port that the server will listen for transactions on
+	Cert             string // CertFlag defines a flag for the server's TLS certificate.
+	Key              string // KeyFlag defines a flag for the server's TLS key.
 	DataDirectory    string // DataDirectory defines the host systems folder directory holding the database and config files
 	LogVerbosity     string // LogVerbosity defines the logging level {debug, info, warn, error, fatal, panic}
 	ConfigFile       string // Location of the TOML config file, including directory path

--- a/godbledger/cmd/flags.go
+++ b/godbledger/cmd/flags.go
@@ -59,6 +59,26 @@ var (
 		Name:  "config",
 		Usage: "TOML configuration file",
 	}
+	// RPCHost defines the host on which the RPC server should listen.
+	RPCHost = &cli.StringFlag{
+		Name:  "rpc-host",
+		Usage: "Host on which the RPC server should listen",
+	}
+	// RPCPort defines a beacon node RPC port to open.
+	RPCPort = &cli.StringFlag{
+		Name:  "rpc-port",
+		Usage: "RPC port exposed by GoDBLedger",
+	}
+	// CertFlag defines a flag for the node's TLS certificate.
+	CertFlag = &cli.StringFlag{
+		Name:  "tls-cert",
+		Usage: "Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.",
+	}
+	// KeyFlag defines a flag for the node's TLS key.
+	KeyFlag = &cli.StringFlag{
+		Name:  "tls-key",
+		Usage: "Key for secure gRPC. Pass this and the tls-cert flag in order to use gRPC securely.",
+	}
 )
 
 func setConfig(ctx *cli.Context, cfg *LedgerConfig) {
@@ -71,5 +91,17 @@ func setConfig(ctx *cli.Context, cfg *LedgerConfig) {
 	}
 	if ctx.IsSet(DataDirFlag.Name) {
 		cfg.ConfigFile = ctx.String(DataDirFlag.Name)
+	}
+	if ctx.IsSet(RPCHost.Name) {
+		cfg.Host = ctx.String(RPCHost.Name)
+	}
+	if ctx.IsSet(RPCPort.Name) {
+		cfg.RPCPort = ctx.String(RPCPort.Name)
+	}
+	if ctx.IsSet(CertFlag.Name) {
+		cfg.Cert = ctx.String(CertFlag.Name)
+	}
+	if ctx.IsSet(KeyFlag.Name) {
+		cfg.Key = ctx.String(KeyFlag.Name)
 	}
 }

--- a/godbledger/main.go
+++ b/godbledger/main.go
@@ -30,7 +30,12 @@ func startNode(ctx *cli.Context) error {
 		return err
 	}
 	fullnode.Register(ledger)
-	rpc := rpc.NewRPCService(context.Background(), &rpc.Config{Port: cfg.RPCPort, Host: cfg.Host}, ledger)
+	rpc := rpc.NewRPCService(context.Background(), &rpc.Config{
+		Host:     cfg.Host,
+		Port:     cfg.RPCPort,
+		CertFlag: cfg.Cert,
+		KeyFlag:  cfg.Key,
+	}, ledger)
 	fullnode.Register(rpc)
 	fullnode.Start()
 

--- a/godbledger/rpc/service.go
+++ b/godbledger/rpc/service.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/reflection"
 
 	"github.com/darcys22/godbledger/godbledger/ledger"
 	pb "github.com/darcys22/godbledger/proto"
@@ -19,28 +21,35 @@ func init() {
 }
 
 type Service struct {
-	ld         *ledger.Ledger
-	ctx        context.Context
-	cancel     context.CancelFunc
-	grpcServer *grpc.Server
-	listener   net.Listener
-	port       string
-	host       string
+	ld              *ledger.Ledger
+	ctx             context.Context
+	cancel          context.CancelFunc
+	grpcServer      *grpc.Server
+	listener        net.Listener
+	port            string
+	host            string
+	withCert        string
+	withKey         string
+	credentialError error
 }
 
 type Config struct {
-	Port string
-	Host string
+	Port     string
+	Host     string
+	CertFlag string
+	KeyFlag  string
 }
 
 func NewRPCService(ctx context.Context, cfg *Config, l *ledger.Ledger) *Service {
 	ctx, cancel := context.WithCancel(ctx)
 	return &Service{
-		ld:     l,
-		ctx:    ctx,
-		cancel: cancel,
-		port:   cfg.Port,
-		host:   cfg.Host,
+		ld:       l,
+		ctx:      ctx,
+		cancel:   cancel,
+		port:     cfg.Port,
+		host:     cfg.Host,
+		withCert: cfg.CertFlag,
+		withKey:  cfg.KeyFlag,
 	}
 }
 
@@ -53,12 +62,32 @@ func (s *Service) Start() {
 		log.Errorf("Could not listen to port in Start() %s: %v", address, err)
 	}
 	s.listener = lis
-	log.WithField("port", s.port).Info("Listening on port")
-	s.grpcServer = grpc.NewServer()
+	log.WithField("address", address).Info("GRPC Listening on port")
+
+	opts := []grpc.ServerOption{}
+
+	if s.withCert != "" && s.withKey != "" {
+		creds, err := credentials.NewServerTLSFromFile(s.withCert, s.withKey)
+		if err != nil {
+			log.Errorf("Could not load TLS keys: %s", err)
+			s.credentialError = err
+		}
+		opts = append(opts, grpc.Creds(creds))
+	} else {
+		log.Warn("You are using an insecure gRPC server. If you are running your GoDBLedger Server and " +
+			"client on the same machine, you can ignore this message.")
+		//"client on the same machine, you can ignore this message. If you want to know " +
+		//"how to enable secure connections, see: https://docs.prylabs.network/docs/prysm-usage/secure-grpc")
+	}
+
+	s.grpcServer = grpc.NewServer(opts...)
 
 	ledgerServer := &LedgerServer{ld: s.ld}
 
 	pb.RegisterTransactorServer(s.grpcServer, ledgerServer)
+
+	// Register reflection service on gRPC server.
+	reflection.Register(s.grpcServer)
 
 	go func() {
 		if s.listener != nil {
@@ -82,5 +111,8 @@ func (s *Service) Stop() error {
 
 // Status returns nil or credentialError
 func (s *Service) Status() error {
+	if s.credentialError != nil {
+		return s.credentialError
+	}
 	return nil
 }


### PR DESCRIPTION
GoDBLedger will eventually need to be run on a server with ports open
to the public, this endpoint will need to be secure and GRPC has the
ability to lock down the with mutual TLS

addresses #13 

