### PR TITLE
Rename most log messages to debug

### DIFF
--- a/godbledger/cmd/config.go
+++ b/godbledger/cmd/config.go
@@ -65,7 +65,6 @@ var (
 
 func MakeConfig(cli *cli.Context) (error, *LedgerConfig) {
 
-	log.Infof("Setting up configuration")
 	config := defaultLedgerConfig
 	//set logrus verbosity
 	level, err := logrus.ParseLevel(config.LogVerbosity)
@@ -77,8 +76,6 @@ func MakeConfig(cli *cli.Context) (error, *LedgerConfig) {
 	if len(cli.String("config")) > 0 {
 		config.ConfigFile = cli.String("config")
 	}
-
-	log.Debugf("Filepath to config file: %s", config.ConfigFile)
 	err = InitConfig(config)
 	if err != nil {
 		log.Debugf("Error initialising config: %s", err)
@@ -100,6 +97,7 @@ func MakeConfig(cli *cli.Context) (error, *LedgerConfig) {
 		return err, nil
 	}
 	logrus.SetLevel(level)
+	log.WithField("Config File", config.ConfigFile).Debug("Configuration Successfully loaded")
 
 	return nil, config
 }
@@ -107,7 +105,7 @@ func MakeConfig(cli *cli.Context) (error, *LedgerConfig) {
 func InitConfig(config *LedgerConfig) error {
 	_, err := os.Stat(config.ConfigFile)
 	if os.IsNotExist(err) {
-		log.Infof("Config File doesn't exist creating at %s", config.ConfigFile)
+		log.Debugf("Config File doesn't exist creating at %s", config.ConfigFile)
 		os.MkdirAll(filepath.Dir(config.ConfigFile), os.ModePerm)
 		buf := new(bytes.Buffer)
 		if err := toml.NewEncoder(buf).Encode(config); err != nil {

--- a/godbledger/db/mysqldb/mysqldb.go
+++ b/godbledger/db/mysqldb/mysqldb.go
@@ -77,7 +77,7 @@ func NewDB(connection_string string) (*Database, error) {
 }
 
 func (db *Database) InitDB() error {
-	log.Info("Initialising DB Table")
+	log.Debug("Initialising DB Table")
 
 	//USERS
 	createDB := `

--- a/godbledger/db/mysqldb/mysqlfuncs.go
+++ b/godbledger/db/mysqldb/mysqlfuncs.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (db *Database) AddTransaction(txn *core.Transaction) (string, error) {
-	log.Info("Adding Transaction to DB")
+	log.Debug("Adding Transaction to DB")
 
 	posterID := ""
 	err := db.DB.QueryRow(`SELECT user_id FROM users WHERE username = ? LIMIT 1`, txn.Poster.Name).Scan(&posterID)
@@ -64,7 +64,7 @@ func (db *Database) AddTransaction(txn *core.Transaction) (string, error) {
 	stmt, _ = tx.Prepare(sqlStr)
 	log.Debug("Query: " + sqlStr)
 	log.Debugf("NumberVals = %d", len(vals))
-	log.Info("Adding Split to DB")
+	log.Debug("Adding Split to DB")
 	res, err = stmt.Exec(vals...)
 	if err != nil {
 		log.Fatal(err)
@@ -86,7 +86,7 @@ func (db *Database) AddTransaction(txn *core.Transaction) (string, error) {
 	tx2, _ := db.DB.Begin()
 	accStmt, _ := tx2.Prepare(sqlAccStr)
 	log.Debug("Query: " + sqlAccStr)
-	log.Info("Adding Split Accounts to DB")
+	log.Debug("Adding Split Accounts to DB")
 	res, err = accStmt.Exec(accVals...)
 	if err != nil {
 		log.Fatal(err)
@@ -110,7 +110,7 @@ func (db *Database) AddTransaction(txn *core.Transaction) (string, error) {
 func (db *Database) FindTransaction(txnID string) (*core.Transaction, error) {
 	var resp core.Transaction
 	var poster core.User
-	log.Info("Searching Transaction in DB: ", txnID)
+	log.Debugf("Searching Transaction in DB: %s", txnID)
 
 	// Find the transaction body
 	err := db.DB.QueryRow(`
@@ -129,7 +129,7 @@ func (db *Database) FindTransaction(txnID string) (*core.Transaction, error) {
 		return nil, err
 	}
 
-	log.Info("Searching Transaction splits in DB")
+	log.Debug("Searching Transaction splits in DB")
 
 	// Find all splits relating to that transaction
 	splits, err := db.Query(`
@@ -189,7 +189,7 @@ func (db *Database) DeleteTransaction(txnID string) error {
 
 func (db *Database) FindTag(tag string) (int, error) {
 	var resp int
-	log.Info("Searching Tag in DB")
+	log.Debug("Searching Tag in DB")
 	err := db.DB.QueryRow(`SELECT tag_id FROM tags WHERE tag_name = ? LIMIT 1`, tag).Scan(&resp)
 	if err != nil {
 		log.Debug("Find Tag Failed: ", err)
@@ -199,7 +199,7 @@ func (db *Database) FindTag(tag string) (int, error) {
 }
 
 func (db *Database) AddTag(tag string) error {
-	log.Info("Adding Tag to DB")
+	log.Debug("Adding Tag to DB")
 	insertTag := `
 		INSERT INTO tags(tag_name)
 			VALUES(?);
@@ -398,7 +398,7 @@ func (db *Database) DeleteTagFromTransaction(txnID, tag string) error {
 
 func (db *Database) FindCurrency(cur string) (*core.Currency, error) {
 	var resp core.Currency
-	log.Info("Searching Currency in DB: ", cur)
+	log.Debugf("Searching Currency in DB: %s", cur)
 	err := db.DB.QueryRow(`SELECT * FROM currencies WHERE name = ? LIMIT 1`, strings.TrimSpace(cur)).Scan(&resp.Name, &resp.Decimals)
 	if err != nil {
 		return nil, err
@@ -407,7 +407,7 @@ func (db *Database) FindCurrency(cur string) (*core.Currency, error) {
 }
 
 func (db *Database) AddCurrency(cur *core.Currency) error {
-	log.Info("Adding Currency to DB")
+	log.Debug("Adding Currency to DB")
 	insertCurrency := `
 		INSERT INTO currencies(name,decimals)
 			VALUES(?,?);
@@ -458,7 +458,7 @@ func (db *Database) DeleteCurrency(currency string) error {
 
 func (db *Database) FindAccount(code string) (*core.Account, error) {
 	var resp core.Account
-	log.Info("Searching Account in DB")
+	log.Debug("Searching Account in DB")
 	err := db.DB.QueryRow(`SELECT * FROM accounts WHERE account_id = ? LIMIT 1`, strings.TrimSpace(code)).Scan(&resp.Code, &resp.Name)
 	if err != nil {
 		return nil, err
@@ -467,7 +467,7 @@ func (db *Database) FindAccount(code string) (*core.Account, error) {
 }
 
 func (db *Database) AddAccount(acc *core.Account) error {
-	log.Info("Adding Account to DB")
+	log.Debug("Adding Account to DB")
 	insertAccount := `
 		INSERT INTO accounts(account_id, name)
 			VALUES(?,?);
@@ -506,7 +506,7 @@ func (db *Database) SafeAddAccount(acc *core.Account) error {
 
 func (db *Database) FindUser(pubKey string) (*core.User, error) {
 	var resp core.User
-	log.Info("Searching User in DB")
+	log.Debug("Searching User in DB")
 	err := db.DB.QueryRow(`SELECT * FROM users WHERE username = ? LIMIT 1`, pubKey).Scan(&resp.Id, &resp.Name)
 	if err != nil {
 		return nil, err
@@ -515,7 +515,7 @@ func (db *Database) FindUser(pubKey string) (*core.User, error) {
 }
 
 func (db *Database) AddUser(usr *core.User) error {
-	log.Info("Adding User to DB")
+	log.Debug("Adding User to DB")
 	insertUser := `
 		INSERT INTO users(user_id, username)
 			VALUES(?,?);
@@ -553,7 +553,7 @@ func (db *Database) SafeAddUser(usr *core.User) error {
 }
 
 func (db *Database) TestDB() error {
-	log.Info("Testing DB")
+	log.Debug("Testing DB")
 	createDB := "create table if not exists pages (title text, body blob, timestamp text)"
 	log.Debug("Query: " + createDB)
 	res, err := db.DB.Exec(createDB)
@@ -677,7 +677,7 @@ func (db *Database) GetListing(startDate, endDate time.Time) (*[]core.Transactio
 
 	var txns []core.Transaction
 
-	log.Infof("Searching Transactions in DB between %s & %s", startDate.Format("2006-01-02"), endDate.Format("2006-01-02"))
+	log.Debugf("Searching Transactions in DB between %s & %s", startDate.Format("2006-01-02"), endDate.Format("2006-01-02"))
 
 	// Find the transaction bodys
 	rows, err := db.DB.Query(`

--- a/godbledger/db/sqlite3db/sqlite3db.go
+++ b/godbledger/db/sqlite3db/sqlite3db.go
@@ -24,7 +24,7 @@ func (db *Database) Close() error {
 
 // NewDB initializes a new DB.
 func NewDB(dirPath string) (*Database, error) {
-	log.Info("Creating DB")
+	log.Debug("Creating DB")
 	if err := os.MkdirAll(dirPath, 0700); err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func NewDB(dirPath string) (*Database, error) {
 }
 
 func (db *Database) InitDB() error {
-	log.Info("Initialising DB Table")
+	log.Debug("Initialising DB Table")
 
 	//USERS
 	createDB := `

--- a/godbledger/db/sqlite3db/sqlite3funcs.go
+++ b/godbledger/db/sqlite3db/sqlite3funcs.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (db *Database) AddTransaction(txn *core.Transaction) (string, error) {
-	log.Info("Adding Transaction to DB")
+	log.Debug("Adding Transaction to DB")
 
 	posterID := ""
 	err := db.DB.QueryRow(`SELECT user_id FROM users WHERE username = ? LIMIT 1`, txn.Poster.Name).Scan(&posterID)
@@ -64,7 +64,7 @@ func (db *Database) AddTransaction(txn *core.Transaction) (string, error) {
 	stmt, _ = tx.Prepare(sqlStr)
 	log.Debug("Query: " + sqlStr)
 	log.Debugf("NumberVals = %d", len(vals))
-	log.Info("Adding Split to DB")
+	log.Debug("Adding Split to DB")
 	res, err = stmt.Exec(vals...)
 	if err != nil {
 		log.Fatal(err)
@@ -86,7 +86,7 @@ func (db *Database) AddTransaction(txn *core.Transaction) (string, error) {
 	tx2, _ := db.DB.Begin()
 	accStmt, _ := tx2.Prepare(sqlAccStr)
 	log.Debug("Query: " + sqlAccStr)
-	log.Info("Adding Split Accounts to DB")
+	log.Debug("Adding Split Accounts to DB")
 	res, err = accStmt.Exec(accVals...)
 	if err != nil {
 		log.Fatal(err)
@@ -110,7 +110,7 @@ func (db *Database) AddTransaction(txn *core.Transaction) (string, error) {
 func (db *Database) FindTransaction(txnID string) (*core.Transaction, error) {
 	var resp core.Transaction
 	var poster core.User
-	log.Info("Searching Transaction in DB: ", txnID)
+	log.Debugf("Searching Transaction in DB: %s", txnID)
 
 	// Find the transaction body
 	err := db.DB.QueryRow(`
@@ -129,7 +129,7 @@ func (db *Database) FindTransaction(txnID string) (*core.Transaction, error) {
 		return nil, err
 	}
 
-	log.Info("Searching Transaction splits in DB")
+	log.Debug("Searching Transaction splits in DB")
 
 	// Find all splits relating to that transaction
 	splits, err := db.Query(`
@@ -189,7 +189,7 @@ func (db *Database) DeleteTransaction(txnID string) error {
 
 func (db *Database) FindTag(tag string) (int, error) {
 	var resp int
-	log.Info("Searching Tag in DB")
+	log.Debug("Searching Tag in DB")
 	err := db.DB.QueryRow(`SELECT tag_id FROM tags WHERE tag_name = $1 LIMIT 1`, tag).Scan(&resp)
 	if err != nil {
 		log.Debug("Find Tag Failed: ", err)
@@ -199,7 +199,7 @@ func (db *Database) FindTag(tag string) (int, error) {
 }
 
 func (db *Database) AddTag(tag string) error {
-	log.Info("Adding Tag to DB")
+	log.Debug("Adding Tag to DB")
 	insertTag := `
 		INSERT INTO tags(tag_name)
 			VALUES(?);
@@ -398,7 +398,7 @@ func (db *Database) DeleteTagFromTransaction(txnID, tag string) error {
 
 func (db *Database) FindCurrency(cur string) (*core.Currency, error) {
 	var resp core.Currency
-	log.Info("Searching Currency in DB")
+	log.Debug("Searching Currency in DB")
 	err := db.DB.QueryRow(`SELECT * FROM currencies WHERE name = $1 LIMIT 1`, strings.TrimSpace(cur)).Scan(&resp.Name, &resp.Decimals)
 	if err != nil {
 		return nil, err
@@ -407,7 +407,7 @@ func (db *Database) FindCurrency(cur string) (*core.Currency, error) {
 }
 
 func (db *Database) AddCurrency(cur *core.Currency) error {
-	log.Info("Adding Currency to DB")
+	log.Debug("Adding Currency to DB")
 	insertCurrency := `
 		INSERT INTO currencies(name,decimals)
 			VALUES(?,?);
@@ -458,7 +458,7 @@ func (db *Database) DeleteCurrency(currency string) error {
 
 func (db *Database) FindAccount(code string) (*core.Account, error) {
 	var resp core.Account
-	log.Info("Searching Account in DB")
+	log.Debug("Searching Account in DB")
 	err := db.DB.QueryRow(`SELECT * FROM accounts WHERE account_id = $1 LIMIT 1`, strings.TrimSpace(code)).Scan(&resp.Code, &resp.Name)
 	if err != nil {
 		return nil, err
@@ -467,7 +467,7 @@ func (db *Database) FindAccount(code string) (*core.Account, error) {
 }
 
 func (db *Database) AddAccount(acc *core.Account) error {
-	log.Info("Adding Account to DB")
+	log.Debug("Adding Account to DB")
 	insertAccount := `
 		INSERT INTO accounts(account_id, name)
 			VALUES(?,?);
@@ -506,7 +506,7 @@ func (db *Database) SafeAddAccount(acc *core.Account) error {
 
 func (db *Database) FindUser(pubKey string) (*core.User, error) {
 	var resp core.User
-	log.Info("Searching User in DB")
+	log.Debug("Searching User in DB")
 	err := db.DB.QueryRow(`SELECT * FROM users WHERE username = $1 LIMIT 1`, pubKey).Scan(&resp.Id, &resp.Name)
 	if err != nil {
 		return nil, err
@@ -515,7 +515,7 @@ func (db *Database) FindUser(pubKey string) (*core.User, error) {
 }
 
 func (db *Database) AddUser(usr *core.User) error {
-	log.Info("Adding User to DB")
+	log.Debug("Adding User to DB")
 	insertUser := `
 		INSERT INTO users(user_id, username)
 			VALUES(?,?);
@@ -554,7 +554,7 @@ func (db *Database) SafeAddUser(usr *core.User) error {
 }
 
 func (db *Database) TestDB() error {
-	log.Info("Testing DB")
+	log.Debug("Testing DB")
 	createDB := "create table if not exists pages (title text, body blob, timestamp text)"
 	log.Debug("Query: " + createDB)
 	res, err := db.DB.Exec(createDB)
@@ -682,7 +682,7 @@ func (db *Database) GetListing(startDate, endDate time.Time) (*[]core.Transactio
 
 	var txns []core.Transaction
 
-	log.Infof("Searching Transactions in DB between %s & %s", startDate.Format("2006-01-02"), endDate.Format("2006-01-02"))
+	log.Debugf("Searching Transactions in DB between %s & %s", startDate.Format("2006-01-02"), endDate.Format("2006-01-02"))
 
 	// Find the transaction bodys
 	rows, err := db.DB.Query(`

--- a/godbledger/ledger/ledger.go
+++ b/godbledger/ledger/ledger.go
@@ -60,10 +60,10 @@ func New(ctx *cli.Context, cfg *cmd.LedgerConfig) (*Ledger, error) {
 			return nil, err
 		}
 	case "memorydb":
-		log.Info("Using in memory database")
+		log.Debug("Using in memory database")
 		log.Fatal("In memory database not implemented")
 	default:
-		log.Println("No implementation available for that database.")
+		log.Fatal("No implementation available for that database.")
 	}
 
 	log.Debug("Initialised database configuration")
@@ -72,8 +72,7 @@ func New(ctx *cli.Context, cfg *cmd.LedgerConfig) (*Ledger, error) {
 }
 
 func (l *Ledger) Insert(txn *core.Transaction) (string, error) {
-	log.Infof("Created Transaction: %v", txn)
-	log.Debugf("Creating Safely added user: %v", txn.Poster)
+	log.WithField("transaction", txn).Debug("Created Transaction")
 	l.LedgerDb.SafeAddUser(txn.Poster)
 	currencies, _ := l.GetCurrencies(txn)
 	for _, currency := range currencies {
@@ -95,19 +94,16 @@ func (l *Ledger) Insert(txn *core.Transaction) (string, error) {
 }
 
 func (l *Ledger) Delete(txnID string) {
-	log.Infof("Deleting Transaction: %s", txnID)
 	l.LedgerDb.DeleteTransaction(txnID)
 }
 
 func (l *Ledger) Void(txnID string, usr *core.User) error {
-	log.Infof("Voiding Transaction: %s", txnID)
-
 	txn, err := l.LedgerDb.FindTransaction(txnID)
 	if err != nil {
 		return err
 	}
 
-	log.Debugf("Transaction: %+v", txn)
+	log.Debugf("Transaction Found to Void: %+v", txn)
 
 	newTxn, err := core.ReverseTransaction(txn, usr)
 	if err != nil {
@@ -138,12 +134,10 @@ func (l *Ledger) Void(txnID string, usr *core.User) error {
 }
 
 func (l *Ledger) InsertTag(account, tag string) error {
-	log.Infof("Creating Tag %s on %s", tag, account)
 	return l.LedgerDb.SafeAddTagToAccount(account, tag)
 }
 
 func (l *Ledger) DeleteTag(account, tag string) error {
-	log.Infof("Deleting Tag %s from %s", tag, account)
 	return l.LedgerDb.DeleteTagFromAccount(account, tag)
 }
 
@@ -171,12 +165,10 @@ func (l *Ledger) GetCurrencies(txn *core.Transaction) ([]*core.Currency, error) 
 }
 
 func (l *Ledger) InsertCurrency(curr *core.Currency) error {
-	log.Infof("Creating Currency %s with %d decimals", curr.Name, curr.Decimals)
 	return l.LedgerDb.SafeAddCurrency(curr)
 }
 
 func (l *Ledger) DeleteCurrency(currency string) error {
-	log.Infof("Deleting Currency %s", currency)
 	return l.LedgerDb.DeleteCurrency(currency)
 }
 

--- a/godbledger/node/node.go
+++ b/godbledger/node/node.go
@@ -52,7 +52,7 @@ func (n *Node) Start() {
 	n.lock.Lock()
 	log.WithFields(logrus.Fields{
 		"version": version.Version,
-	}).Info("Starting ledger node")
+	}).Info("Starting GoDBLedger Server")
 
 	n.services.StartAll()
 	stop := n.stop

--- a/godbledger/rpc/ledger_server.go
+++ b/godbledger/rpc/ledger_server.go
@@ -18,7 +18,7 @@ type LedgerServer struct {
 }
 
 func (s *LedgerServer) AddTransaction(ctx context.Context, in *pb.TransactionRequest) (*pb.TransactionResponse, error) {
-	log.Printf("Received New Transaction Request")
+	log.WithField("Request", in).Info("Received New Add Transaction Request")
 
 	usr, err := core.NewUser("MainUser")
 	if err != nil {
@@ -73,14 +73,14 @@ func (s *LedgerServer) AddTransaction(ctx context.Context, in *pb.TransactionReq
 }
 
 func (s *LedgerServer) DeleteTransaction(ctx context.Context, in *pb.DeleteRequest) (*pb.TransactionResponse, error) {
-	log.Info("Received New Delete Request")
+	log.WithField("Request", in).Info("Received New Delete Request")
 	s.ld.Delete(in.GetIdentifier())
 
 	return &pb.TransactionResponse{Message: "Accepted"}, nil
 }
 
 func (s *LedgerServer) VoidTransaction(ctx context.Context, in *pb.DeleteRequest) (*pb.TransactionResponse, error) {
-	log.Info("Received New Void Request")
+	log.WithField("Request", in).Info("Received New Void Request")
 
 	usr, err := core.NewUser("MainUser")
 	if err != nil {
@@ -97,12 +97,12 @@ func (s *LedgerServer) VoidTransaction(ctx context.Context, in *pb.DeleteRequest
 }
 
 func (s *LedgerServer) NodeVersion(ctx context.Context, in *pb.VersionRequest) (*pb.VersionResponse, error) {
-	log.Info("Received Version Request: %s", in)
+	log.WithField("Request", in).Info("Received New Version Request")
 	return &pb.VersionResponse{Message: version.Version}, nil
 }
 
 func (s *LedgerServer) AddTag(ctx context.Context, in *pb.TagRequest) (*pb.TransactionResponse, error) {
-	log.Info("Received New Add Tag Request")
+	log.WithField("Request", in).Info("Received New Add Tag Request")
 
 	s.ld.InsertTag(in.GetAccount(), in.GetTag())
 
@@ -110,14 +110,14 @@ func (s *LedgerServer) AddTag(ctx context.Context, in *pb.TagRequest) (*pb.Trans
 }
 
 func (s *LedgerServer) DeleteTag(ctx context.Context, in *pb.DeleteTagRequest) (*pb.TransactionResponse, error) {
-	log.Info("Received New Delete Tag Request")
+	log.WithField("Request", in).Info("Received New Delete Tag Request")
 	s.ld.DeleteTag(in.GetAccount(), in.GetTag())
 
 	return &pb.TransactionResponse{Message: "Accepted"}, nil
 }
 
 func (s *LedgerServer) AddCurrency(ctx context.Context, in *pb.CurrencyRequest) (*pb.TransactionResponse, error) {
-	log.Info("Received New Add Currency Request")
+	log.WithField("Request", in).Info("Received New Add Currency Request")
 
 	curr, err := core.NewCurrency(in.GetCurrency(), int(in.GetDecimals()))
 	if err != nil {
@@ -133,14 +133,14 @@ func (s *LedgerServer) AddCurrency(ctx context.Context, in *pb.CurrencyRequest) 
 }
 
 func (s *LedgerServer) DeleteCurrency(ctx context.Context, in *pb.DeleteCurrencyRequest) (*pb.TransactionResponse, error) {
-	log.Info("Received New Delete Currency Request")
+	log.WithField("Request", in).Info("Received New Delete Currency Request")
 	s.ld.DeleteCurrency(in.GetCurrency())
 
 	return &pb.TransactionResponse{Message: "Accepted"}, nil
 }
 
 func (s *LedgerServer) GetTB(ctx context.Context, in *pb.TBRequest) (*pb.TBResponse, error) {
-	log.Info("Received New TB Request")
+	log.WithField("Request", in).Info("Received New Get Trial Balance Request")
 	response := pb.TBResponse{}
 
 	querydate, err := time.Parse("2006-01-02", in.Date)
@@ -180,7 +180,7 @@ func (s *LedgerServer) GetTB(ctx context.Context, in *pb.TBRequest) (*pb.TBRespo
 }
 
 func (s *LedgerServer) GetListing(ctx context.Context, in *pb.ReportRequest) (*pb.ListingResponse, error) {
-	log.Info("Received New Listing Request")
+	log.WithField("Request", in).Info("Received New Get Listing Request")
 	response := pb.ListingResponse{}
 
 	startdate, err := time.Parse("2006-01-02", in.Startdate)

--- a/godbledger/rpc/service.go
+++ b/godbledger/rpc/service.go
@@ -56,7 +56,7 @@ func NewRPCService(ctx context.Context, cfg *Config, l *ledger.Ledger) *Service 
 
 // Start the gRPC server.
 func (s *Service) Start() {
-	log.Info("Starting service")
+	log.Debug("Starting service")
 	address := fmt.Sprintf("%s:%s", s.host, s.port)
 	lis, err := net.Listen("tcp", address)
 	if err != nil {

--- a/reporter/main.go
+++ b/reporter/main.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sirupsen/logrus"
-	//"github.com/urfave/cli"
+	"github.com/darcys22/godbledger/godbledger/cmd"
+
 	"github.com/urfave/cli/v2"
+
+	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 
@@ -29,6 +31,14 @@ func init() {
 		commandTrialBalance,
 		// pdfgenerator.go
 		commandPDFGenerate,
+	}
+	app.Flags = []cli.Flag{
+		cmd.VerbosityFlag,
+		cmd.ConfigFileFlag,
+		cmd.RPCHost,
+		cmd.RPCPort,
+		cmd.CertFlag,
+		cmd.KeyFlag,
 	}
 	app.Action = reporterConsole
 }


### PR DESCRIPTION
Feel like the log output was too polluted and eventually the default
will be set to info and all you will want to see is when a transaction
is received and if it was successful. All the debugging messages
should be hideable

addresses #71 