### PR TITLE
Add Decimal Places to Ledger_CLI and Reporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ clean:
 	rm -rf release/
 	rm -rf cert/
 
+lint:
+	GO111MODULE=on go run utils/ci.go lint
+
 travis:
 	GO111MODULE=on go run utils/ci.go install
 	GO111MODULE=on go run utils/ci.go test -coverage $$TEST_PACKAGES

--- a/ledger_cli/transaction.go
+++ b/ledger_cli/transaction.go
@@ -105,10 +105,11 @@ func Send(cfg *cmd.LedgerConfig, t *Transaction) error {
 	transactionLines := make([]*pb.LineItem, 2)
 
 	for i, accChange := range t.AccountChanges {
+		amountInt64 := accChange.Balance.Num().Int64() * int64(100) / accChange.Balance.Denom().Int64()
 		transactionLines[i] = &pb.LineItem{
 			Accountname: accChange.Name,
 			Description: accChange.Description,
-			Amount:      accChange.Balance.Num().Int64(),
+			Amount:      amountInt64,
 			Currency:    accChange.Currency,
 		}
 	}

--- a/ledger_cli/wizard.go
+++ b/ledger_cli/wizard.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/darcys22/godbledger/godbledger/cmd"
 
-	//"github.com/urfave/cli"
+	"github.com/marcmak/calc/calc"
 	"github.com/urfave/cli/v2"
 )
 
@@ -58,12 +58,10 @@ var commandWizardJournal = &cli.Command{
 			lineAccount, _ := reader.ReadString('\n')
 
 			fmt.Print("Enter the Amount: ")
-			var i int64
-			_, err := fmt.Scanf("%d", &i)
-			if err != nil {
-				panic(err)
-			}
-			lineAmount := big.NewRat(i, 1)
+			lineAmountStr, _ := reader.ReadString('\n')
+
+			lineAmount := new(big.Rat)
+			lineAmount.SetFloat64(calc.Solve(lineAmountStr))
 
 			transactionLines = append(transactionLines, Account{
 				Name:        lineAccount,
@@ -90,13 +88,13 @@ var commandWizardJournal = &cli.Command{
 
 		bytes, err := json.Marshal(req)
 		if err != nil {
-			fmt.Println("Can't serialize", req)
+			return fmt.Errorf("Can't Serialize (%v)", err)
 		}
 		fmt.Printf("%v => %v, '%v'\n", req, bytes, string(bytes))
 
 		err = Send(cfg, req)
 		if err != nil {
-			log.Fatalf("could not send: %v", err)
+			return fmt.Errorf("could not send: %v", err)
 		}
 
 		return nil


### PR DESCRIPTION
The amounts are stored in the databases as integers, originally was
planning on keeping everything in the ledger_cli and reporter
executables as integers aswell and enforcing the use of smallest units
as integers (cents) rather than allowing for the larger units (dollars).

However the code pulled from https://github.com/howeyc/ledger for the
parsing of ledger text files was processing decimals and the
datastructure being used in ledger_cli was allowing for it. Rather than
keeping inconsistencies with some parts being integer and some parts
allowing decimal this makes everything decimal.

This will cause a breaking change as inputs will now be for whole
dollars and will then save into the database a cents. Previously if a
person had been using the api as cents they will need to update it for
dollars. IF a person had been using the api as dollars previously then
all of their data will be stored as a number off by a factor of 100.