### PR TITLE
enable build & test on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOBIN = ./build/bin GO ?= latest
 GORUN = env GO111MODULE=on go run
 
 # build all platforms by default
-build: test $(PLATFORMS)
+build: $(PLATFORMS)
 
 # generate a build target for each platform
 .PHONY: $(PLATFORMS)
@@ -16,14 +16,14 @@ $(PLATFORMS):
 		GOOS=$(os) GOARCH=amd64 GO111MODULE=on go build -o release/$(BINARY)-$(os)-x64-v$(VERSION)/ ./...
 
 .PHONY: release
-release: linux
+release: linux test
 
 PHONY: clean
 clean:
 	rm -rf release/
 	rm -rf cert/
 
-test:
+test: build
 	GO111MODULE=on go test ./...
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 BINARY := godbledger
 VERSION ?= latest
-PLATFORMS := linux
+PLATFORMS := linux darwin
 os = $(word 1, $@)
 
 GOBIN = ./build/bin GO ?= latest
 GORUN = env GO111MODULE=on go run
 
+# build all platforms by default
+build: $(PLATFORMS)
+
+# generate a build target for each platform
 .PHONY: $(PLATFORMS)
 $(PLATFORMS):
 		mkdir -p release/$(BINARY)-$(os)-x64-v$(VERSION)/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOBIN = ./build/bin GO ?= latest
 GORUN = env GO111MODULE=on go run
 
 # build all platforms by default
-build: $(PLATFORMS)
+build: test $(PLATFORMS)
 
 # generate a build target for each platform
 .PHONY: $(PLATFORMS)

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ clean:
 	rm -rf release/
 	rm -rf cert/
 
+test:
+	GO111MODULE=on go test ./...
+
 lint:
 	GO111MODULE=on go run utils/ci.go lint
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Go DB Ledger
+# GoDBLedger
 
 [![Build Status]][Build Link] [![Book Status]][Book Link] [![Chat Badge]][Chat Link]
 
@@ -11,25 +11,37 @@
 
 GoDBLedger is an open source accounting system that aims to make the recording of double entry bookkeeping transactions programmable. It provide users with normal features that most finance systems tend to lack such as api endpoints for your scripts and a database backend with a clear schema so you can analyse your financial data using your software of choice. The ultimate goal is for your whole financial process to be automated from data entry to compilation of financials/tax returns.
 
+- [How it works](#how-it-works)
+- [Architecture](#architecture)
+  - [Executables](#executables)
+  - [Communicating with Godbledger and software examples](#communicating-with-godbledger-and-software-examples)
+  - [Database and configuration](#database-and-configuration)
+  - [Building the Proto Buffers](#building-the-proto-buffers)
+  - [SQL Querys](#sql-querys)
+- [Contributing](#contributing)
+  - [Building GoDBLedger](#building-godbledger)
+- [Roadmap](#roadmap)
 
-#### How it works:
+## How it works
+
 You are a business or individual wanting a system to record your profits and produce financial reports. You dont want to pay a cloud provider and you want to keep your financial data under your own control. You spin up a linux server (or raspberry pi) choose a database (Currently SQLite3 and MySQL are available) and you set up GoDBLedger to run on that server. You now have a place to send your double entry bookkeeping transactions which get saved into your own database! 
 
 GoDBLedger gives you an api for the recording of transactions and there are  some command line binaries included to get you started.
 
 [Watch the demo video](https://youtu.be/svyw9EOZuuc)
 
-To get started view the quickstart on the wiki:
+To get started using GoDBLedger view the quickstart on the wiki:
 https://github.com/darcys22/godbledger/wiki/Quickstart
 
+## Architecture
 
-## Executables
+### Executables
 
-| Command| Description |
-| :----------------- | :---------------------------------------------------------------------------------------------------------| 
-| **`Godbledger`**    | The main server. It is the access point for transactions that will be saved to the accounting database. |
-| `Ledger_cli`     | A CLI client that can be used to transmit transactions to the server.                             |
-| `Reporter`      | Builds basic reports from the database on the command line.                                             |
+| Command          | Description                                                                                             |
+| :--------------- | :------------------------------------------------------------------------------------------------------ |
+| **`Godbledger`** | The main server. It is the access point for transactions that will be saved to the accounting database. |
+| `Ledger_cli`     | A CLI client that can be used to transmit transactions to the server.                                   |
+| `Reporter`       | Builds basic reports from the database on the command line.                                             |
 
 ### Communicating with Godbledger and software examples
 
@@ -94,7 +106,19 @@ SELECT * FROM accounts where account_id in (select account_id from account_tag w
 
 ```
 
-### TODO/Milestones
+## Contributing
+
+### Building GoDBLedger
+
+GoDBLedger uses a `Makefile` to manage build steps and the default target is `build`
+
+```
+make
+```
+
+This will build the code for default platforms.
+
+## Roadmap
 - ~~GoDBLedger server runs and accepts transactions~~
 - ~~trial balance and transaction reports of journals~~
 - ~~analyse database using metabase to create financial dashboard~~

--- a/godbledger/cmd/flags.go
+++ b/godbledger/cmd/flags.go
@@ -27,7 +27,7 @@ func DefaultDataDir() string {
 	home := homeDir()
 	if home != "" {
 		if runtime.GOOS == "darwin" {
-			return filepath.Join(home, "Library", "ledger")
+			return filepath.Join(home, ".ledger")
 		} else if runtime.GOOS == "windows" {
 			return filepath.Join(home, "AppData", "Roaming", "ledger")
 		} else {

--- a/tests/components/godbledger_node.go
+++ b/tests/components/godbledger_node.go
@@ -4,6 +4,8 @@ package components
 
 import (
 	"os/exec"
+	"runtime"
+
 	//"strings"
 	"fmt"
 	"strings"
@@ -30,8 +32,9 @@ func StartGoDBLedger(t *testing.T, config *cmd.LedgerConfig) int {
 		fmt.Sprintf("--database-location=%s", config.DatabaseLocation),
 	}
 
-	cmd := exec.Command("../build/bin/godbledger", args...)
-	t.Logf("Starting GoDBLedger with flags: %s", strings.Join(args[:], " "))
+	binPath := fmt.Sprintf("../release/godbledger-%s-x64-vlatest/godbledger", runtime.GOOS)
+	cmd := exec.Command(binPath, args...)
+	t.Logf("Starting GoDBLedger (%s) with flags: %s", binPath, strings.Join(args[:], " "))
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Failed to start GoDBLedger Server: %v", err)
 	}

--- a/tests/minimal_e2e_test.go
+++ b/tests/minimal_e2e_test.go
@@ -2,6 +2,9 @@ package tests
 
 import (
 	"flag"
+	"os"
+	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/urfave/cli/v2"
@@ -15,7 +18,33 @@ func TestEndToEnd_MinimalConfig(t *testing.T) {
 
 	// Create a config from the defaults which would usually be created by the CLI library
 	set := flag.NewFlagSet("test", 0)
-	set.String("config", "", "doc")
+	set.String("datadir", "", "data directory")
+	set.String("config", "", "config file")
+	set.String("database-location", "", "database location")
+
+	testDataDir, err := filepath.Abs("../release/test-data")
+	if err != nil {
+		t.Fatalf("Calculating path to test data dir: %v", err)
+	}
+	testConfigFile := path.Join(testDataDir, "config.toml")
+	if fileExists(testConfigFile) {
+		err := os.Remove(testConfigFile)
+		if err != nil {
+			t.Fatalf("Removing old test Config file failed: %v", err)
+		}
+	}
+	testDatabaseLocation := path.Join(testDataDir, "ledger.db")
+	if fileExists(testDatabaseLocation) {
+		err := os.Remove(testDatabaseLocation)
+		if err != nil {
+			t.Fatalf("Removing old test database file failed: %v", err)
+		}
+	}
+
+	set.Set("datadir", testDataDir)
+	set.Set("config", testConfigFile)
+	set.Set("config", testDatabaseLocation)
+
 	ctx := cli.NewContext(nil, set, nil)
 	err, cfg := cmd.MakeConfig(ctx)
 	if err != nil {
@@ -30,4 +59,12 @@ func TestEndToEnd_MinimalConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	runEndToEndTest(t, cfg)
+}
+
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
 }


### PR DESCRIPTION
> as a Mac user
> I want the contribution setup to be smooth on `darwin`
> in order to take advantage of Golang's cross-compile features and simplify contributing

this PR:
- adds `darwin` as a build target to the makefile
- adds a new `build` default target which depends on both platform build targets
- adds a `test` make target which runs `go test ./...` on the repo, as a new dependency of `release`
- updates e2e test configuration to:
    - run the output of the `build` task (from the `./release/...` folders)
    - use `./release/test-data` as a data directory during e2e test runs
    - remove old test config and database files as setup for every e2e test run
- updates the README with a bit of heading structure and a new `Contributing` section where we can accumulate notes on contributing