### PR TITLE
update xgo dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,5 +23,5 @@ require (
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	google.golang.org/grpc v1.30.0
-	src.techknowlogick.com/xgo v1.0.1-0.20200717030703-5c3bb7fc435e // indirect
+	src.techknowlogick.com/xgo v1.1.1-0.20201113032224-51945c0192ab // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -255,3 +255,5 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 src.techknowlogick.com/xgo v1.0.1-0.20200717030703-5c3bb7fc435e h1:cNlfcCyMwIq/KyKPgpuPohdDr9EjtxX0b44sGYSV2Ic=
 src.techknowlogick.com/xgo v1.0.1-0.20200717030703-5c3bb7fc435e/go.mod h1:31CE1YKtDOrKTk9PSnjTpe6YbO6W/0LTYZ1VskL09oU=
+src.techknowlogick.com/xgo v1.1.1-0.20201113032224-51945c0192ab h1:nt4v+ILEOvuF9p4W6L03GtbfBvzrwRiov5Z8pvLVPrQ=
+src.techknowlogick.com/xgo v1.1.1-0.20201113032224-51945c0192ab/go.mod h1:31CE1YKtDOrKTk9PSnjTpe6YbO6W/0LTYZ1VskL09oU=


### PR DESCRIPTION
this can cause the xgo-based make tasks to fail
since part of the utils/ci.go xgo command runs
'go get src.techknowlogick.com/xgo' it seems to
always get latest of the xgo dependency.

at the same time the xgo-based build targets
appear to build inside an xgo container which
downloads the source code from github instead
of referencing the source code in my local
working copy, and as such when it runs
'go get src.techknowlogick.com/xgo' that command
updates go.mod and go.sum but then the xgo-based
build fails with an error like this:

    go: writing go.sum: open /ext-go/1/src/go-repo/go.sum747278511.tmp: read-only file system
    2019/09/11 15:45:50 Failed to cross compile package: exit status 1.

for more detail see https://github.com/techknowlogick/xgo/issues/36