### PR TITLE
Mysql GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,4 @@ jobs:
     - name: Build
       run: go run utils/ci.go build
     - name: Test
-      run: go run utils/ci.go test --integration -v
+      run: go run utils/ci.go test --mysql -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,13 @@ jobs:
           - 3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s
     steps:
+    - name: Verify MySQL connection
+      env:
+        PORT: ${{ job.services.mysql.ports[3306] }}
+      run: |
+        while ! mysqladmin ping -h"127.0.0.1" -P"$PORT" --silent; do
+          sleep 1
+        done
     - name: Install Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,5 @@ jobs:
       uses: actions/checkout@v2
     - name: Build
       run: go run utils/ci.go build
-    - name: Verify MySQL connection
-        env:
-          PORT: ${{ job.services.mysql.ports[3306] }}
-        run: |
-          while ! mysqladmin ping -h"127.0.0.1" -P"$PORT" --silent; do
-            sleep 1
-          done
     - name: Test
       run: go run utils/ci.go test --integration -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,24 @@ jobs:
         go-version: [1.14.x, 1.15.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Build
+      run: go run utils/ci.go build
+    - name: Test
+      run: go run utils/ci.go test --integration -v
+  mysqltest:
+    strategy:
+      fail-fast: false # dont' want one scenario failing to deprive us of feedback on the others
+      matrix:
+        go-version: [1.14.x, 1.15.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     services:
       mysql:
         image: mysql:5.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
         go-version: [1.14.x, 1.15.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_USER: godbledger
+          MYSQL_PASSWORD: password
+          MYSQL_DATABASE: ledger
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
@@ -39,5 +50,12 @@ jobs:
       uses: actions/checkout@v2
     - name: Build
       run: go run utils/ci.go build
+    - name: Verify MySQL connection
+        env:
+          PORT: ${{ job.services.mysql.ports[3306] }}
+        run: |
+          while ! mysqladmin ping -h"127.0.0.1" -P"$PORT" --silent; do
+            sleep 1
+          done
     - name: Test
       run: go run utils/ci.go test --integration -v

--- a/tests/endtoend_test.go
+++ b/tests/endtoend_test.go
@@ -1,13 +1,10 @@
-// Package endtoend performs full a end-to-end test for GoDBLedger,
+// Package provides a full a end-to-end test for GoDBLedger,
 // including spinning up a server and making sure its running, and sending test data to verify
-
-// +build integration
 
 package tests
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"strconv"
@@ -24,7 +21,6 @@ import (
 	e2e "github.com/darcys22/godbledger/tests/params"
 	"github.com/darcys22/godbledger/tests/types"
 
-	"github.com/urfave/cli/v2"
 	"google.golang.org/grpc"
 )
 
@@ -36,20 +32,7 @@ var evaluators = []types.Evaluator{
 	ev.TradingSimulator,
 }
 
-func TestEndToEnd_MinimalConfig(t *testing.T) {
-
-	// Create a config from the defaults which would usually be created by the CLI library
-	set := flag.NewFlagSet("test", 0)
-	set.String("config", "", "doc")
-	ctx := cli.NewContext(nil, set, nil)
-	err, cfg := cmd.MakeConfig(ctx)
-	if err != nil {
-		t.Fatalf("New Config Failed: %v", err)
-	}
-
-	// Set the Database type to a SQLite3 in memory database
-	cfg.DatabaseType = "memorydb"
-
+func runEndToEndTest(t *testing.T, cfg *cmd.LedgerConfig) {
 	processIDs := []int{}
 	logFiles := []*os.File{}
 	for i := 0; i < len(evaluators); i++ {
@@ -97,7 +80,7 @@ func TestEndToEnd_MinimalConfig(t *testing.T) {
 	req := &transaction.VersionRequest{
 		Message: "Test",
 	}
-	_, err = client.NodeVersion(context.Background(), req)
+	_, err := client.NodeVersion(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -1,0 +1,32 @@
+// Package mysql performs full a end-to-end test for GoDBLedger specifically using a mysql backend,
+// including spinning up a server and making sure its running, and sending test data to verify
+
+// +build mysql
+
+package tests
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/darcys22/godbledger/godbledger/cmd"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestMySQL(t *testing.T) {
+
+	// Create a config from the defaults which would usually be created by the CLI library
+	set := flag.NewFlagSet("test", 0)
+	set.String("config", "", "doc")
+	ctx := cli.NewContext(nil, set, nil)
+	err, cfg := cmd.MakeConfig(ctx)
+	if err != nil {
+		t.Fatalf("New Config Failed: %v", err)
+	}
+
+	// Set the Database type to a MySQL database
+	cfg.DatabaseType = "mysql"
+
+	runEndToEndTest(t, cfg)
+}

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/darcys22/godbledger/godbledger/cmd"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
 )
 
@@ -28,5 +29,6 @@ func TestMySQL(t *testing.T) {
 	// Set the Database type to a MySQL database
 	cfg.DatabaseType = "mysql"
 
+	assert.Equal(t, "mysql", cfg.DatabaseType)
 	//runEndToEndTest(t, cfg)
 }

--- a/tests/mysql_test.go
+++ b/tests/mysql_test.go
@@ -28,5 +28,5 @@ func TestMySQL(t *testing.T) {
 	// Set the Database type to a MySQL database
 	cfg.DatabaseType = "mysql"
 
-	runEndToEndTest(t, cfg)
+	//runEndToEndTest(t, cfg)
 }

--- a/tests/sqlite_test.go
+++ b/tests/sqlite_test.go
@@ -1,0 +1,32 @@
+// Package performs full a end-to-end test for GoDBLedger using the SQLLite database backend,
+// including spinning up a server and making sure its running, and sending test data to verify
+
+// +build integration
+
+package tests
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/darcys22/godbledger/godbledger/cmd"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestSQLite(t *testing.T) {
+
+	// Create a config from the defaults which would usually be created by the CLI library
+	set := flag.NewFlagSet("test", 0)
+	set.String("config", "", "doc")
+	ctx := cli.NewContext(nil, set, nil)
+	err, cfg := cmd.MakeConfig(ctx)
+	if err != nil {
+		t.Fatalf("New Config Failed: %v", err)
+	}
+
+	// Set the Database type to a SQLite3 in memory database
+	cfg.DatabaseType = "memorydb"
+
+	runEndToEndTest(t, cfg)
+}

--- a/tests/sqlite_test.go
+++ b/tests/sqlite_test.go
@@ -1,8 +1,6 @@
 // Package performs full a end-to-end test for GoDBLedger using the SQLLite database backend,
 // including spinning up a server and making sure its running, and sending test data to verify
 
-// +build integration
-
 package tests
 
 import (

--- a/utils/ci.go
+++ b/utils/ci.go
@@ -333,7 +333,7 @@ func doTest(cmdline []string) {
 	if *integration {
 		gotest.Args = append(gotest.Args, "-tags=\"integration\"")
 	}
-	if *integration {
+	if *mysql {
 		gotest.Args = append(gotest.Args, "-tags=\"mysql\"")
 	}
 	if *verbose {

--- a/utils/ci.go
+++ b/utils/ci.go
@@ -330,7 +330,7 @@ func doTest(cmdline []string) {
 		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover")
 	}
 	if *integration {
-		gotest.Args = append(gotest.Args, "-tags=integration")
+		gotest.Args = append(gotest.Args, "-tags=\"integration mysql\"")
 	}
 	if *verbose {
 		gotest.Args = append(gotest.Args, "-v")

--- a/utils/ci.go
+++ b/utils/ci.go
@@ -313,6 +313,7 @@ func doTest(cmdline []string) {
 	coverage := flag.Bool("coverage", false, "Whether to record code coverage")
 	verbose := flag.Bool("v", false, "Whether to log verbosely")
 	integration := flag.Bool("integration", false, "Whether to run integration tests")
+	mysql := flag.Bool("mysql", false, "Whether to run mysql integration tests")
 	flag.CommandLine.Parse(cmdline)
 	env := build.Env()
 
@@ -330,7 +331,10 @@ func doTest(cmdline []string) {
 		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover")
 	}
 	if *integration {
-		gotest.Args = append(gotest.Args, "-tags=\"integration mysql\"")
+		gotest.Args = append(gotest.Args, "-tags=\"integration\"")
+	}
+	if *integration {
+		gotest.Args = append(gotest.Args, "-tags=\"mysql\"")
 	}
 	if *verbose {
 		gotest.Args = append(gotest.Args, "-v")

--- a/utils/ci.go
+++ b/utils/ci.go
@@ -331,10 +331,10 @@ func doTest(cmdline []string) {
 		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover")
 	}
 	if *integration {
-		gotest.Args = append(gotest.Args, "-tags=\"integration\"")
+		gotest.Args = append(gotest.Args, "-tags=integration")
 	}
 	if *mysql {
-		gotest.Args = append(gotest.Args, "-tags=\"mysql\"")
+		gotest.Args = append(gotest.Args, "-tags=mysql")
 	}
 	if *verbose {
 		gotest.Args = append(gotest.Args, "-v")


### PR DESCRIPTION
Addressing #117 and ongoing #49

The integration tests need to be run for all the databases we support. Currently its mysql and sqlite and it would be better to have mysql tested thoroughly asap.

Adds a new service container to the github actions.

Will create a separate test file that reruns all the integration tests