### PR TITLE
GH-127 provide default k8s resource yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Godbledger comes with a `docker-compose.yml` file and some make targets to help 
 
    **NOTE** you may risk losing data if you type `ctrl-c` twice and force an early shutdown of mysql
 
+### Running in Kubernetes
+
+We provide [sample yaml files](./utils/kubernetes/README.md) which demonstrate how to configure and deploy `mysql` and `godbledger` to a kubernetes cluster. 
+
 ## Building the Proto Buffers
 Ensure that you have the latest version of the `protobuf` toolchain (currently at `3.14.0`):
 

--- a/utils/kubernetes/README.md
+++ b/utils/kubernetes/README.md
@@ -1,0 +1,119 @@
+# Deploying to Kubernetes
+
+[Kubernetes](https://kubernetes.io/) (often abbreviated as `k8s`) is a common orchestration platform for automating the deployment, scaling, and management of containerized applications.
+
+## Files
+
+This directory contains example spec yaml which can get you up and running locally in minikube or the kubernetes instance offered by Docker Desktop.  They can also serve as examples to be modified for deployment to a kuberentes cluster hosted remotely.
+
+| file                     | description                                                                                |
+| ------------------------ | ------------------------------------------------------------------------------------------ |
+| k8s.00.namespace.yml     | creates a `godbledger` namespace                                                           |
+| k8s.01.mysql.secrets.yml | creates a secret resource with MYSQL credentials                                           |
+| k8s.02.mysql.volume.yml  | creates a persistent storage volume for the `mysql` database                               |
+| k8s.03.mysql.yml         | spins up `mysql` deployment and service                                                    |
+| k8s.04.godbledger.yml    | spins up a `godbledger` deployment (running the `godbledger` app on port 8080) and service |
+| k8s.config.toml          | a config file with connection details to `mysql` and `godbledger`                          |
+
+Couple of notes on these files:
+
+- they are all configured with a single [namespace](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/namespace-v1/) called `godbledger`
+
+- there is nothing here which requires these resources to be in a single namespace
+
+- how you organize your kubernetes deployments is up to you, but notice that there is a `metadata.namespace` property in each of these resources which may need to updated if you make different choices.
+
+## Apply
+
+You can run these commands from any directory; simply adjust the pathed arguments accordingly.
+
+1. Build the `godbledger:latest` container image:
+
+    ```
+    make build-docker
+    ```
+
+1. Create a [Namespace](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/namespace-v1/) to contain the godbledger resources:
+
+    ```
+    kubectl apply -f ./k8s.00.namespace.yml
+    ```
+
+1. Create a [Secret]() resource to store the mysql root password and godbledger user credentials:
+
+    ```
+    kubectl apply -f ./k8s.01.mysql.secrets.yml
+    ```
+
+1. Create a [Persistent Volume](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/) and [Persistent Volume Claim](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/) to store the mysql data files:
+
+    ```
+    kubectl apply -f ./k8s.02.mysql.volume.yml 
+    ```
+
+    A PersistentVolume (PV) is "a storage resource provisioned by an administrator".  It maps some storage location from outside the cluster to be accessable to (i.e. mountable by) workloads running inside the cluster.
+
+    Persistent storage is important for a database server running inside kubernetes because by design, most resources in kubernetes are ephemeral and can be destroyed and recreated automatically by the orchestration layer for a variety of reasons.  By storing the msyql data files outside the ephemeral container you ensure that it is more durable and will survive across mysql pod restarts.
+
+    A PersistentVolumeClaim (PVC) is "a user's request for and claim to a Persistent Volume".
+    
+    In this case we are creating a `mysql-pv-claim` claim for the `mysql` server to own the `mysql-pv-volume` volume.
+
+1. Create the mysql server deployment:
+
+    ```
+    kubectl apply -f ./k8s.03.mysql.yml
+    ```
+
+    This creates a `mysql` [Deployment](https://kubernetes.io/docs/reference/kubernetes-api/workloads-resources/deployment-v1/) and `mysql` [Service](https://kubernetes.io/docs/reference/kubernetes-api/services-resources/service-v1/) resource which is listening inside the cluster on `mysql:3306`.
+
+    Root password and credentials for the `godbledger` user are pulled dynamically from the `mysql-creds` secret resources configured in step 3.
+
+    The `nodePort:30036` setting binds the service to receive traffic directed to port `30036` on the host node (i.e. `localhost:30036` from your host machine).
+    
+    The godbledger user credentials and This `nodePort` value is configured also in `k8s.config.toml` to allow `reporter` running on the host machine to connect directly to the mysql server:
+
+    ```toml
+    DatabaseType = "mysql"
+    DatabaseLocation = "godbledger:password@tcp(localhost:30036)/ledger?charset=utf8mb4,utf8"
+    ```
+
+    ```toml
+    Host = "127.0.0.1"
+    RPCPort = "30080"
+    ```
+
+1. Create the `godbledger` Deployment and `godbledger` Service:
+
+    ```
+    kubectl apply -f ./k8s.04.godbledger.yml
+    ```
+
+    This creates a `godbledger` deployment and service able to receive traffic internally via cluster DNS at `godbledger:8080` and over the nodePort on port `30080`.
+
+    This `nodePort` value is configured also in `k8s.config.toml` to allow `ledger_cli` running on the host machine to connect directly to the godbledger server:
+
+    ```toml
+    Host = "127.0.0.1"
+    RPCPort = "30080"
+    ```
+
+1. Run apps locally and connect to your kubernetes deployments:
+
+    - build the apps from source (if you don't have them installed locally):
+
+        ```
+        make build-native
+        ```
+
+    - `ledger_cli` connects to the godbledger server API over gRPC:
+
+        ```
+        ledger_cli --config ./k8s.config.toml
+        ```
+
+    - `reporter` connects directly to the database:
+
+        ```
+        reporter --config ./k8s.config.toml
+        ```

--- a/utils/kubernetes/k8s.00.namespace.yml
+++ b/utils/kubernetes/k8s.00.namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: godbledger

--- a/utils/kubernetes/k8s.01.mysql.secrets.yml
+++ b/utils/kubernetes/k8s.01.mysql.secrets.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-creds
+  namespace: godbledger
+type: Opaque
+stringData: # change this to 'data:' to use base64 encoded strings instead of plaintext
+  root_password: admin
+  godbledger_user: godbledger
+  godbledger_pass: password

--- a/utils/kubernetes/k8s.02.mysql.volume.yml
+++ b/utils/kubernetes/k8s.02.mysql.volume.yml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mysql-pv-volume
+  namespace: godbledger
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /mnt/mysql
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim
+  namespace: godbledger
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/utils/kubernetes/k8s.03.mysql.yml
+++ b/utils/kubernetes/k8s.03.mysql.yml
@@ -1,0 +1,67 @@
+# apt update
+# apt-get update
+# apt install net-tools
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: godbledger
+  labels:
+    name: mysql
+spec:
+  type: NodePort
+  ports:
+    - port: 3306
+      targetPort: 3306
+      nodePort: 30036
+      name: mysql
+  selector:
+    app: mysql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-creds
+              key: root_password
+        - name: MYSQL_DATABASE
+          value: ledger
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: mysql-creds
+              key: godbledger_user
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-creds
+              key: godbledger_pass
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-pv-claim

--- a/utils/kubernetes/k8s.04.godbledger.yml
+++ b/utils/kubernetes/k8s.04.godbledger.yml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: godbledger
+  namespace: godbledger
+spec:
+  type: NodePort
+  selector:
+    app: godbledger
+    role: server
+  ports:
+  - port: 8080
+    targetPort: 8080
+    nodePort: 30080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: godbledger
+  namespace: godbledger
+  labels:
+    app: godbledger
+    role: server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: godbledger
+      role: server
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: godbledger
+        role: server
+    spec:
+      containers:
+      - name: godbledger
+        image: godbledger:latest
+        imagePullPolicy: Never # change this when deploying to a real cluster
+        ports:
+        - containerPort: 8080
+        env:
+        - name: MYSQL_DATABASE
+          value: ledger
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: mysql-creds
+              key: godbledger_user
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-creds
+              key: godbledger_pass
+        - name: WAIT_HOSTS
+          value: mysql:3306
+        - name: WAIT_HOSTS_TIMEOUT
+          value: '300'
+        - name: WAIT_SLEEP_INTERVAL
+          value: '10'
+        - name: WAIT_HOST_CONNECT_TIMEOUT
+          value: '10'
+        command:
+        - ./wait_entrypoint.sh # delays server start until mysql is responding on port 3306
+        - ./godbledger
+        - --verbosity=debug
+        - --rpc-host=0.0.0.0 # listen to traffic from all ips
+        - --rpc-port=8080
+        - --datadir=/var/lib/ledger
+        - --config=/var/lib/ledger/config.toml
+        - --database=mysql
+        - "--database-location=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp(mysql:3306)/$(MYSQL_DATABASE)?charset=utf8mb4,utf8"
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 10

--- a/utils/kubernetes/k8s.config.toml
+++ b/utils/kubernetes/k8s.config.toml
@@ -1,0 +1,8 @@
+Host = "127.0.0.1"
+RPCPort = "30080"
+CACert = ""
+Cert = ""
+Key = ""
+LogVerbosity = "debug"
+DatabaseType = "mysql"
+DatabaseLocation = "godbledger:password@tcp(localhost:30036)/ledger?charset=utf8mb4,utf8"


### PR DESCRIPTION
This PR provides default kubernetes resource yaml which demonstrate how to configure and deploy `mysql` and `godbledger` to a kubernetes cluster.

The sample files are designed to work with a kubernetes cluster running on localhost (e.g. [docker desktop](https://www.docker.com/products/docker-desktop) or [minikube](https://minikube.sigs.k8s.io/docs/start/)) in a `godbledger` namespace using default sample credentials.

These files can serve as examples for deploying `mysql` or `godbledger` to a hosted kubernetes cluster as well.
