### PR TITLE
Reporter filters out accounts not tagged as "main"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/cespare/cp v1.1.1 // indirect
+	github.com/cespare/cp v1.1.1
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/joyt/godate v0.0.0-20150226210126-7151572574a7
@@ -27,5 +27,4 @@ require (
 	google.golang.org/grpc v1.34.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	src.techknowlogick.com/xgo v1.2.1-0.20201205054834-c7ddcb19c3f8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -161,5 +161,3 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-src.techknowlogick.com/xgo v1.2.1-0.20201205054834-c7ddcb19c3f8 h1:zUaoahcWb6b1dL42FljqPWGL6AaO4AUOwygazQwMauQ=
-src.techknowlogick.com/xgo v1.2.1-0.20201205054834-c7ddcb19c3f8/go.mod h1:31CE1YKtDOrKTk9PSnjTpe6YbO6W/0LTYZ1VskL09oU=

--- a/reporter/transactionlisting.go
+++ b/reporter/transactionlisting.go
@@ -86,6 +86,14 @@ If you want to see all the transactions in the database, or export to CSV/JSON
 					WHERE
 						tt.transaction_id = splits.transaction_id
 				)
+				AND "main" IN (
+				  SELECT
+					  t.tag_name
+					FROM
+					  tags AS t
+					  JOIN account_tag AS at ON at.tag_id = t.tag_id
+					WHERE
+						at.account_id = split_accounts.account_id)
 		;`
 
 		log.Debug("Querying Database")

--- a/reporter/trialbalance.go
+++ b/reporter/trialbalance.go
@@ -68,6 +68,11 @@ If you want to see all the transactions in the database, or export to CSV
 																			 JOIN transaction_tag AS tt
 																				 ON tt.tag_id = t.tag_id
 																WHERE  tt.transaction_id = splits.transaction_id)
+						 AND "main" IN (SELECT t.tag_name
+																FROM   tags AS t
+																			 JOIN account_tag AS at
+																				 ON at.tag_id = t.tag_id
+																WHERE  at.account_id = split_accounts.account_id)
 			GROUP  BY split_accounts.account_id, splits.currency
 
 			;`


### PR DESCRIPTION
The accounts are starting to take into account external accounts such as
bank accounts which do not actually get reported in the trial balance or
GL. The differentiation between "main" accounts and other accounts will
allow us to use the ledger as a database to store external accounts, but
it will also build the foundation to have multiple entities in the
ledger as one entity "main" could be passed and switched which would
have a completely separate ledger.