### PR TITLE
Fix releases script and update PPA to build on tag

### DIFF
--- a/.github/workflows/ppa.yml
+++ b/.github/workflows/ppa.yml
@@ -1,8 +1,8 @@
 name: PPA
 on:
   push:
-    branches:
-      - stable
+    tags:
+      - 'v*'
 jobs:
   ubuntu:
     strategy:

--- a/utils/ci.go
+++ b/utils/ci.go
@@ -68,7 +68,7 @@ var (
 	// NOTE: this could be inferred if these 'main' packages were moved
 	//       into a ./cmd folder (see: https://github.com/golang-standards/project-layout#cmd)
 	packagesToBuild = []string{
-		"godbledger-server",
+		"godbledger",
 		"ledger-cli",
 		"reporter",
 	}


### PR DESCRIPTION
The releases script was broken during the PPA PR, simply the name of the
package was changed.

In addition the PPA workflow wasn't running on tags, have decided to
change the workflow to build on tagging rather than the stable branch.