### PR TITLE
Add account returns if created and tests before tagging

### DIFF
--- a/godbledger/db/database.go
+++ b/godbledger/db/database.go
@@ -29,7 +29,7 @@ type Database interface {
 	DeleteCurrency(currency string) error
 	FindAccount(code string) (*core.Account, error)
 	AddAccount(*core.Account) error
-	SafeAddAccount(*core.Account) error
+	SafeAddAccount(*core.Account) (bool, error)
 	DeleteAccount(accountName string) error
 	FindUser(pubKey string) (*core.User, error)
 	AddUser(usr *core.User) error

--- a/godbledger/db/mysqldb/mysqlfuncs.go
+++ b/godbledger/db/mysqldb/mysqlfuncs.go
@@ -663,12 +663,13 @@ func (db *Database) AddAccount(acc *core.Account) error {
 	return err
 }
 
-func (db *Database) SafeAddAccount(acc *core.Account) error {
+//Returns True if account was created
+func (db *Database) SafeAddAccount(acc *core.Account) (bool, error) {
 	u, _ := db.FindAccount(strings.TrimSpace(acc.Code))
 	if u != nil {
-		return nil
+		return false, nil
 	}
-	return db.AddAccount(acc)
+	return true, db.AddAccount(acc)
 
 }
 

--- a/godbledger/db/sqlite3db/sqlite3funcs.go
+++ b/godbledger/db/sqlite3db/sqlite3funcs.go
@@ -661,12 +661,13 @@ func (db *Database) AddAccount(acc *core.Account) error {
 	return err
 }
 
-func (db *Database) SafeAddAccount(acc *core.Account) error {
-	u, _ := db.FindAccount(acc.Code)
+//Returns True if account was created
+func (db *Database) SafeAddAccount(acc *core.Account) (bool, error) {
+	u, _ := db.FindAccount(strings.TrimSpace(acc.Code))
 	if u != nil {
-		return nil
+		return false, nil
 	}
-	return db.AddAccount(acc)
+	return true, db.AddAccount(acc)
 
 }
 

--- a/godbledger/ledger/ledger.go
+++ b/godbledger/ledger/ledger.go
@@ -86,8 +86,13 @@ func (l *Ledger) Insert(txn *core.Transaction) (string, error) {
 	accounts, _ := l.GetAccounts(txn)
 
 	for _, account := range accounts {
-		l.LedgerDb.SafeAddAccount(account)
-		l.LedgerDb.SafeAddTagToAccount(account.Name, "main")
+		newaccount, err := l.LedgerDb.SafeAddAccount(account)
+		if err != nil {
+			return "", err
+		}
+		if newaccount {
+			l.LedgerDb.SafeAddTagToAccount(account.Name, "main")
+		}
 	}
 
 	response, err := l.LedgerDb.AddTransaction(txn)
@@ -151,7 +156,8 @@ func (l *Ledger) InsertAccount(accountStr string) error {
 	if err != nil {
 		log.Error(err)
 	}
-	return l.LedgerDb.SafeAddAccount(acc)
+	_, err = l.LedgerDb.SafeAddAccount(acc)
+	return err
 }
 
 func (l *Ledger) DeleteAccount(accountStr string) error {


### PR DESCRIPTION
This ensures that if an account already exists when inserting a
transaction that it will not also get tagged main by default. If the
transaction is created new then it will always tag it also with main by
default.