### PR TITLE
Rename brief in transaction table to description

### DIFF
--- a/godbledger/db/mysqldb/mysqldb.go
+++ b/godbledger/db/mysqldb/mysqldb.go
@@ -156,7 +156,7 @@ func (db *Database) InitDB() error {
 	CREATE TABLE IF NOT EXISTS transactions (
 		transaction_id VARCHAR(255) NOT NULL,
 		postdate DATETIME NOT NULL,
-		brief VARCHAR(255),
+		description VARCHAR(255),
 		poster_user_id VARCHAR(255),
 		PRIMARY KEY(transaction_id),
     FOREIGN KEY (poster_user_id) REFERENCES users (user_id) ON DELETE RESTRICT

--- a/godbledger/db/mysqldb/mysqlfuncs.go
+++ b/godbledger/db/mysqldb/mysqlfuncs.go
@@ -30,7 +30,7 @@ func (db *Database) AddTransaction(txn *core.Transaction) (string, error) {
 	}
 
 	insertTransaction := `
-		INSERT INTO transactions(transaction_id, postdate, brief,poster_user_id)
+		INSERT INTO transactions(transaction_id, postdate, description, poster_user_id)
 			VALUES(?,?,?,?);
 	`
 	tx, err := db.DB.Begin()
@@ -284,7 +284,7 @@ func (db *Database) FindTransaction(txnID string) (*core.Transaction, error) {
 	err := db.DB.QueryRow(`
 			SELECT t.transaction_id,
 						 t.postdate,
-						 t.brief,
+						 t.description,
 						 u.user_id,
 						 u.username
 			FROM   transactions AS t
@@ -949,7 +949,7 @@ func (db *Database) GetListing(startDate, endDate time.Time) (*[]core.Transactio
 		SELECT
         t.transaction_id
         ,t.postdate
-        ,t.brief
+        ,t.description
         ,u.user_id
         ,u.username
     FROM

--- a/godbledger/db/sqlite3db/sqlite3db.go
+++ b/godbledger/db/sqlite3db/sqlite3db.go
@@ -122,7 +122,7 @@ func (db *Database) InitDB() error {
 	CREATE TABLE IF NOT EXISTS transactions (
 		transaction_id VARCHAR(255) NOT NULL,
 		postdate DATETIME NOT NULL,
-		brief VARCHAR(255),
+		description VARCHAR(255),
 		poster_user_id VARCHAR(255),
 		PRIMARY KEY(transaction_id),
     FOREIGN KEY (poster_user_id) REFERENCES users (user_id) ON DELETE RESTRICT

--- a/godbledger/db/sqlite3db/sqlite3funcs.go
+++ b/godbledger/db/sqlite3db/sqlite3funcs.go
@@ -29,7 +29,7 @@ func (db *Database) AddTransaction(txn *core.Transaction) (string, error) {
 	}
 
 	insertTransaction := `
-		INSERT INTO transactions(transaction_id, postdate, brief,poster_user_id)
+		INSERT INTO transactions(transaction_id, postdate, description, poster_user_id)
 			VALUES(?,?,?,?);
 	`
 	tx, err := db.DB.Begin()
@@ -282,7 +282,7 @@ func (db *Database) FindTransaction(txnID string) (*core.Transaction, error) {
 	err := db.DB.QueryRow(`
 			SELECT t.transaction_id,
 						 t.postdate,
-						 t.brief,
+						 t.description,
 						 u.user_id,
 						 u.username
 			FROM   transactions AS t
@@ -953,7 +953,7 @@ func (db *Database) GetListing(startDate, endDate time.Time) (*[]core.Transactio
 		SELECT
         t.transaction_id
         ,t.postdate
-        ,t.brief
+        ,t.description
         ,u.user_id
         ,u.username
     FROM


### PR DESCRIPTION
## Overview
- I renamed the column name, brief in transaction table to description.
- Fixed [#171 ](https://github.com/darcys22/godbledger/issues/171)