### PR TITLE
GH-186 explicitly set docker platform to linux/amd64 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,13 @@ linux-arm-64:
 build-docker: docker-build
 
 docker-build:
-	docker build -t godbledger:$(VERSION) -t godbledger:latest -f ./utils/Dockerfile.build .
+	docker build --platform linux/amd64 -t godbledger:$(VERSION) -t godbledger:latest -f ./utils/Dockerfile.build .
 
 docker-login:
 	@$(if $(strip $(shell docker ps | grep godbledger-server)), @docker exec -it godbledger-server /bin/ash || 0, @docker run -it --rm --entrypoint /bin/ash godbledger:$(VERSION) )
 
 docker-start:
-	GDBL_DATA_DIR=$(GDBL_DATA_DIR) GDBL_LOG_LEVEL=$(GDBL_LOG_LEVEL) GDBL_VERSION=$(VERSION) docker-compose up
+	DOCKER_DEFAULT_PLATFORM=linux/amd64 GDBL_DATA_DIR=$(GDBL_DATA_DIR) GDBL_LOG_LEVEL=$(GDBL_LOG_LEVEL) GDBL_VERSION=$(VERSION) docker-compose up
 
 docker-stop:
 	docker-compose down

--- a/utils/Dockerfile.build
+++ b/utils/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-alpine AS builder
+FROM --platform=linux/amd64 golang:1.15.5-alpine AS builder
 # https://megamorf.gitlab.io/2019/09/08/alpine-go-builds-with-cgo-enabled/
 
 RUN apk update
@@ -12,7 +12,7 @@ ADD . .
 # TODO: pull app version from VERSION
 RUN make
 
-FROM alpine
+FROM --platform=linux/amd64 alpine
 
 # netcat is needed by wait-for
 RUN apk add net-tools


### PR DESCRIPTION
for compatibility with docker-desktop on `darwin/arm64` hosts

tested on:
- 2015 MacBook Pro (`darwin/amd64`) / Docker Desktop `4.2.0`
- 2021 M1 MacBook Pro (`darwin/arm64`) / Docker Desktop `4.4.2`