### PR TITLE
Update Dockerfile.build to use golang:1.19-alpine

### DIFF
--- a/utils/Dockerfile.build
+++ b/utils/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.15.5-alpine AS builder
+FROM --platform=linux/amd64 golang:1.19-alpine AS builder
 # https://megamorf.gitlab.io/2019/09/08/alpine-go-builds-with-cgo-enabled/
 
 RUN apk update


### PR DESCRIPTION
The go.mod file requires go 1.19. However, the Dockerfile.build is pulling the golang alpine image from golang:1.15.5-alpine. This results in an error during the "RUN make" step in Dockerfile.build: 

> \# github.com/darcys22/godbledger/internal/build
> internal/build/download.go:39:18: undefined: os.ReadFile
> internal/build/local.go:132:13: undefined: os.WriteFile
> internal/build/util.go:76:18: undefined: os.ReadFile
> note: module requires Go 1.19
> make: *** [Makefile:42: build-native] Error 2
> The command '/bin/sh -c make' returned a non-zero code: 2
> make: *** [Makefile:80: docker-build] Error 2

Updating Dockerfile.build to use golang:1.19-alpine instead.